### PR TITLE
Foreign nation takes Taiwan bug fix

### DIFF
--- a/GFM/events/CHIFlavor.txt
+++ b/GFM/events/CHIFlavor.txt
@@ -5385,6 +5385,8 @@ country_event = {
 	desc = "EVTDESC131746"
 	picture = "rebellion"
 	
+	fire_only_once = yes
+	
 	trigger = {
 		owns = 2681
 		NOT = {


### PR DESCRIPTION
The event for when a foreign country takes Taiwan fires constantly. This change will fix that by making it fire only once.