### PR TITLE
Decisions requirements and BB changed

### DIFF
--- a/GFM/decisions/more decisions.txt
+++ b/GFM/decisions/more decisions.txt
@@ -1402,14 +1402,19 @@ political_decisions = {
         allow = {
             war = no
             is_disarmed = no
-            has_unclaimed_cores = no
             OR = {
                 war_policy = pro_military
                 war_policy = jingoism
             }
         }
         effect = {
-            badboy = 7
+            random_list = {
+			10 = { badboy = 4 }
+			25 = { badboy = 5 }
+			25 = { badboy = 6 }
+			35 = { badboy = 7 }
+			5 = { badboy = 8 }
+		}
             set_country_flag = mexico_caribbean
             add_accepted_culture = caribeno
             2222 = { add_core = MEX }
@@ -1430,14 +1435,19 @@ political_decisions = {
         allow = {
             war = no
             is_disarmed = no
-            has_unclaimed_cores = no
             OR = {
                 war_policy = pro_military
                 war_policy = jingoism
             }
         }
         effect = {
-            badboy = 11
+		random_list = {
+			10 = { badboy = 8 }
+			25 = { badboy = 9 }
+			25 = { badboy = 10 }
+			35 = { badboy = 11 }
+			5 = { badboy = 12 }
+		}
             set_country_flag = mexico_central_america
             add_accepted_culture = central_american
             UCA_2186 = { add_core = MEX }


### PR DESCRIPTION
I removed the "Does not have unclaimed cores" requirement. This might cause the Refute Manifest Destiny decision to be locked, but i am going to change that as well.