### PR TITLE
Refute Manifest Destiny Fixed

### DIFF
--- a/GFM/decisions/MEX.txt
+++ b/GFM/decisions/MEX.txt
@@ -147,16 +147,6 @@ political_decisions = {
                     USA = { has_recently_lost_war = yes }
                 }
             }
-            any_core = { 
-				continent = north_america 
-				NOT = { 
-					province_id = 2190 
-					province_id = 2196 
-					province_id = 2200 
-					province_id = 3393
-				} 
-				owned_by = THIS 
-			}
         }
 
         effect = {


### PR DESCRIPTION
This is so if you claim Central merica and the Caribbean or anything else actually, you can still Refute Manifest Destiny.