### PR TITLE
Fix #125 - Don't show Treaty of Shimonoseki if Tainan and Peking are owned by different tags

### DIFF
--- a/GFM/decisions/Japan.txt
+++ b/GFM/decisions/Japan.txt
@@ -1547,6 +1547,7 @@ political_decisions = {
             OR = {
                 1485 = {
                     owner = {
+                        owns = 1616
                         is_culture_group = east_asian
                         war_with = THIS
                         NOT = {


### PR DESCRIPTION
This change simply checks that 1485 owner also owns 1616 since conditions on 1485 are used to trigger, but 1616 owner gets the event. So, as in the situation described in #125, the decision now would not be available unless Qing also own Peking, in which case they successfully cede Formosa to Japan.