### PR TITLE
Don't allow Treaty of Shimonoseki due to truce with nonexistent nation

### DIFF
--- a/GFM/decisions/Japan.txt
+++ b/GFM/decisions/Japan.txt
@@ -1556,8 +1556,14 @@ political_decisions = {
                         }
                     }
                 }
-                truce_with = QNG
-                truce_with = TPG
+                QNG = {
+                    truce_with = THIS
+                    exists = yes
+                }
+                TPG = {
+                    truce_with = THIS
+                    exists = yes
+                }
             }
         }
 


### PR DESCRIPTION
Similar but unrelated to #125 and #126, after annexing the Qing in Formosa I still got the decision for the treaty. The "truce with Qing" condition was fulfilled despite the Qing not existing any more. This change requires the truced country to exist.