### PR TITLE
rpl insta-death fix

### DIFF
--- a/GFM/events/CANFlavor.txt
+++ b/GFM/events/CANFlavor.txt
@@ -1450,11 +1450,25 @@ country_event = {
         random_country = {
             limit = {
                 tag = RPL
+                ai = yes
                 exists = yes
                 vassal_of = FROM
             }
             all_core = { remove_core = RPL }
             annex_to = CAN
+        }
+        random_country = {
+            limit = {
+                tag = RPL
+                ai = no
+                exists = yes
+                vassal_of = FROM
+                CAN = { ai = yes }
+            }
+            inherit = CAN
+            add_accepted_culture = french_canadian
+            all_core = { remove_core = RPL }
+            change_tag = CAN
         }
         random_country = {
             limit = {


### PR DESCRIPTION
fix an event when player plays as RPL and being annexed by CAN