### PR TITLE
Fixing the "Claim Greater Slovenia" Decision

### DIFF
--- a/GFM/decisions/Sitka.txt
+++ b/GFM/decisions/Sitka.txt
@@ -6977,17 +6977,8 @@ political_decisions = {
 				tag = SLO
 				tag = YUG
 			}
-            war = no
             NOT = { has_country_flag = greater_slovenia_claimed }
-			OR = {
-				AND = {
-					war = no
-					NOT = { has_country_modifier = recently_lost_war }
-					has_unclaimed_cores = no
-					war_policy = jingoism
-				}
-				ai = no
-			}
+			ai = no
         }
         allow = {
             war = no


### PR DESCRIPTION
Fix Claim Greater Slovenia Decision by removing nonsensical potential requirements which are already covered by the allow ={} bracket