### PR TITLE
Update Political Leaders #check.txt

### DIFF
--- a/GFM/events/Political Leaders #check.txt
+++ b/GFM/events/Political Leaders #check.txt
@@ -1,796 +1,338 @@
 ############## MONARCHIES############################
 
 country_event = {
-    id = 100040001
-    title = "First Minister Appointed"
-    desc = "A new first minister has been appointed."
-    picture = "danishgovernment"
-    trigger = {
+	id = 100040001
+	title = "First Minister Appointed"
+	desc = "A new first minister has been appointed."
+	picture = "danishgovernment"
+	trigger = {
 		ai = no
-        NOT = {
-            has_country_modifier = expert_diplomat
-            has_country_modifier = successful_industrialist
-            has_country_modifier = ivory_tower_intellectual
-            has_country_modifier = man_of_the_people
-            has_country_modifier = landed_gentleman
-            has_country_modifier = military_man
-            has_country_modifier = lord_admiral
-            has_country_modifier = raving_loon
-            has_country_modifier = luddite
-            has_country_modifier = great_statesman
-            has_country_modifier = backroom_boy
-            has_country_modifier = great_reformer
-            has_country_modifier = gauche_buffoon
-            has_country_modifier = administrative_genius
-            has_country_modifier = visionary_thinker
-            has_country_modifier = competent_placeholder
-            has_country_modifier = imperious_autocrat
-            has_country_modifier = prince_of_terror
-            has_country_modifier = efficient_sociopath
-            has_country_modifier = pig_headed_isolationist
-            has_country_modifier = ambitious_union_boss
-            has_country_modifier = dour_economist
-            has_country_modifier = power_vacuum
-            has_country_flag = minister_found
-        }
-        OR = {
+		NOT = {
+			has_country_modifier = expert_diplomat
+			has_country_modifier = successful_industrialist
+			has_country_modifier = ivory_tower_intellectual
+			has_country_modifier = man_of_the_people
+			has_country_modifier = landed_gentleman
+			has_country_modifier = military_man
+			has_country_modifier = lord_admiral
+			has_country_modifier = raving_loon
+			has_country_modifier = luddite
+			has_country_modifier = great_statesman
+			has_country_modifier = backroom_boy
+			has_country_modifier = great_reformer
+			has_country_modifier = gauche_buffoon
+			has_country_modifier = administrative_genius
+			has_country_modifier = visionary_thinker
+			has_country_modifier = competent_placeholder
+			has_country_modifier = imperious_autocrat
+			has_country_modifier = prince_of_terror
+			has_country_modifier = efficient_sociopath
+			has_country_modifier = pig_headed_isolationist
+			has_country_modifier = ambitious_union_boss
+			has_country_modifier = dour_economist
+			has_country_modifier = power_vacuum
+			has_country_flag = minister_found
+		}
+		OR = {
 			government = absolute_empire
 			government = semi_constitutional_empire
-            government = absolute_monarchy
-            government = prussian_constitutionalism
-        }
-    }
+			government = absolute_monarchy
+			government = prussian_constitutionalism
+		}
+	}
 
-    mean_time_to_happen = {
-        days = 14
-    }
+	mean_time_to_happen = {
+		days = 14
+	}
 
-    immediate = {
-        set_country_flag = minister_found
-    }
+	immediate = {
+		set_country_flag = minister_found
+	}
 
-    option = {
-        name = "I hope they're a good one..."
-        random_list = {
+	option = {
+		name = "I hope they're a good one..."
+		set_country_flag = hidden_tooltip
+		random_owned = {
+			limit = { has_country_flag = hidden_tooltip }
+			remove_country_modifier = expert_diplomat
+			remove_country_modifier = successful_industrialist
+			remove_country_modifier = ivory_tower_intellectual
+			remove_country_modifier = man_of_the_people
+			remove_country_modifier = landed_gentleman
+			remove_country_modifier = military_man
+			remove_country_modifier = lord_admiral
+			remove_country_modifier = raving_loon
+			remove_country_modifier = luddite
+			remove_country_modifier = great_statesman
+			remove_country_modifier = backroom_boy
+			remove_country_modifier = great_reformer
+			remove_country_modifier = gauche_buffoon
+			remove_country_modifier = administrative_genius
+			remove_country_modifier = visionary_thinker
+			remove_country_modifier = competent_placeholder
+			remove_country_modifier = imperious_autocrat
+			remove_country_modifier = prince_of_terror
+			remove_country_modifier = efficient_sociopath
+			remove_country_modifier = pig_headed_isolationist
+			remove_country_modifier = ambitious_union_boss
+			remove_country_modifier = dour_economist
+		}
+		clr_country_flag = hidden_tooltip
+		random_list = {
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = expert_diplomat
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = successful_industrialist
 					duration = 3650
 				}
-				clr_country_flag = minister_found
+				random_owned = {
+					limit = { owner = { civilized = no } }
+					owner = {
+						remove_country_modifier = successful_industrialist
+						add_country_modifier = {
+							name = competent_placeholder
+							duration = 3650
+						}
+					}
+				}
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = ivory_tower_intellectual
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = man_of_the_people
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = landed_gentleman
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = military_man
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = lord_admiral
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = raving_loon
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = luddite
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = great_statesman
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = backroom_boy
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = great_reformer
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = gauche_buffoon
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = administrative_genius
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = visionary_thinker
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = competent_placeholder
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = imperious_autocrat
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = prince_of_terror
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = efficient_sociopath
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = pig_headed_isolationist
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = ambitious_union_boss
 					duration = 3650
 				}
-				clr_country_flag = minister_found
+				random_owned = {
+					limit = { owner = { trade_unions = no_trade_unions } }
+					owner = {
+						remove_country_modifier = ambitious_union_boss
+						add_country_modifier = {
+							name = competent_placeholder
+							duration = 3650
+						}
+					}
+				}
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = dour_economist
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 		}
-    }
+		clr_country_flag = minister_found
+	}
 }
 
 country_event = {
-    id = 100040120
-    title = "First Minister Assassinated"
-    desc = "Our first minister has been murdered!"
-    picture = "danishgovernment"
-    trigger = {
+	id = 100040120
+	title = "First Minister Assassinated"
+	desc = "Our first minister has been murdered!"
+	picture = "danishgovernment"
+	trigger = {
 		ai = no
-        OR = {
-            has_country_modifier = expert_diplomat
-            has_country_modifier = successful_industrialist
-            has_country_modifier = ivory_tower_intellectual
-            has_country_modifier = man_of_the_people
-            has_country_modifier = landed_gentleman
-            has_country_modifier = military_man
-            has_country_modifier = lord_admiral
-            has_country_modifier = raving_loon
-            has_country_modifier = luddite
-            has_country_modifier = great_statesman
-            has_country_modifier = backroom_boy
-            has_country_modifier = great_reformer
-            has_country_modifier = gauche_buffoon
-            has_country_modifier = administrative_genius
-            has_country_modifier = visionary_thinker
-            has_country_modifier = competent_placeholder
-            has_country_modifier = imperious_autocrat
-            has_country_modifier = prince_of_terror
-            has_country_modifier = efficient_sociopath
-            has_country_modifier = pig_headed_isolationist
-            has_country_modifier = ambitious_union_boss
-            has_country_modifier = dour_economist
-            has_country_modifier = power_vacuum
-        }
-        average_militancy = 5
-        OR = {
+		OR = {
+			has_country_modifier = expert_diplomat
+			has_country_modifier = successful_industrialist
+			has_country_modifier = ivory_tower_intellectual
+			has_country_modifier = man_of_the_people
+			has_country_modifier = landed_gentleman
+			has_country_modifier = military_man
+			has_country_modifier = lord_admiral
+			has_country_modifier = raving_loon
+			has_country_modifier = luddite
+			has_country_modifier = great_statesman
+			has_country_modifier = backroom_boy
+			has_country_modifier = great_reformer
+			has_country_modifier = gauche_buffoon
+			has_country_modifier = administrative_genius
+			has_country_modifier = visionary_thinker
+			has_country_modifier = competent_placeholder
+			has_country_modifier = imperious_autocrat
+			has_country_modifier = prince_of_terror
+			has_country_modifier = efficient_sociopath
+			has_country_modifier = pig_headed_isolationist
+			has_country_modifier = ambitious_union_boss
+			has_country_modifier = dour_economist
+			has_country_modifier = power_vacuum
+		}
+		average_militancy = 5
+		OR = {
 			government = absolute_empire
 			government = semi_constitutional_empire
-            government = absolute_monarchy
-            government = prussian_constitutionalism
-        }
-    }
+			government = absolute_monarchy
+			government = prussian_constitutionalism
+		}
+	}
 
-    mean_time_to_happen = {
-        months = 48
-    }
+	mean_time_to_happen = {
+		months = 48
+	}
 
-    option = {
-        name = "A tragedy!"
-        remove_country_modifier = expert_diplomat
-        remove_country_modifier = successful_industrialist
-        remove_country_modifier = ivory_tower_intellectual
-        remove_country_modifier = man_of_the_people
-        remove_country_modifier = landed_gentleman
-        remove_country_modifier = military_man
-        remove_country_modifier = lord_admiral
-        remove_country_modifier = raving_loon
-        remove_country_modifier = luddite
-        remove_country_modifier = great_statesman
-        remove_country_modifier = backroom_boy
-        remove_country_modifier = great_reformer
-        remove_country_modifier = gauche_buffoon
-        remove_country_modifier = administrative_genius
-        remove_country_modifier = visionary_thinker
-        remove_country_modifier = competent_placeholder
-        remove_country_modifier = imperious_autocrat
-        remove_country_modifier = prince_of_terror
-        remove_country_modifier = efficient_sociopath
-        remove_country_modifier = pig_headed_isolationist
-        remove_country_modifier = ambitious_union_boss
-        remove_country_modifier = dour_economist
-        add_country_modifier = {
-            name = national_confusion
-            duration = 365
-        }
+	option = {
+		name = "A tragedy!"
+		remove_country_modifier = expert_diplomat
+		remove_country_modifier = successful_industrialist
+		remove_country_modifier = ivory_tower_intellectual
+		remove_country_modifier = man_of_the_people
+		remove_country_modifier = landed_gentleman
+		remove_country_modifier = military_man
+		remove_country_modifier = lord_admiral
+		remove_country_modifier = raving_loon
+		remove_country_modifier = luddite
+		remove_country_modifier = great_statesman
+		remove_country_modifier = backroom_boy
+		remove_country_modifier = great_reformer
+		remove_country_modifier = gauche_buffoon
+		remove_country_modifier = administrative_genius
+		remove_country_modifier = visionary_thinker
+		remove_country_modifier = competent_placeholder
+		remove_country_modifier = imperious_autocrat
+		remove_country_modifier = prince_of_terror
+		remove_country_modifier = efficient_sociopath
+		remove_country_modifier = pig_headed_isolationist
+		remove_country_modifier = ambitious_union_boss
+		remove_country_modifier = dour_economist
+		add_country_modifier = {
+			name = national_confusion
+			duration = 365
+		}
 
-    }
+	}
 }
 
 
@@ -798,801 +340,343 @@ country_event = {
 
 
 country_event = {
-    id = 100050001
-    title = "Great Leader Emerges"
-    desc = "Our new Great Leader has taken office."
-    picture = "danishgovernment"
-    trigger = {
+	id = 100050001
+	title = "Great Leader Emerges"
+	desc = "Our new Great Leader has taken office."
+	picture = "danishgovernment"
+	trigger = {
 		ai = no
-        NOT = {
-            has_country_modifier = expert_diplomat
-            has_country_modifier = successful_industrialist
-            has_country_modifier = ivory_tower_intellectual
-            has_country_modifier = man_of_the_people
-            has_country_modifier = landed_gentleman
-            has_country_modifier = military_man
-            has_country_modifier = lord_admiral
-            has_country_modifier = raving_loon
-            has_country_modifier = luddite
-            has_country_modifier = great_statesman
-            has_country_modifier = backroom_boy
-            has_country_modifier = great_reformer
-            has_country_modifier = gauche_buffoon
-            has_country_modifier = administrative_genius
-            has_country_modifier = visionary_thinker
-            has_country_modifier = competent_placeholder
-            has_country_modifier = imperious_autocrat
-            has_country_modifier = prince_of_terror
-            has_country_modifier = efficient_sociopath
-            has_country_modifier = pig_headed_isolationist
-            has_country_modifier = ambitious_union_boss
-            has_country_modifier = dour_economist
-            has_country_modifier = power_vacuum
-            has_country_flag = minister_found
-        }
-        OR = {
+		NOT = {
+			has_country_modifier = expert_diplomat
+			has_country_modifier = successful_industrialist
+			has_country_modifier = ivory_tower_intellectual
+			has_country_modifier = man_of_the_people
+			has_country_modifier = landed_gentleman
+			has_country_modifier = military_man
+			has_country_modifier = lord_admiral
+			has_country_modifier = raving_loon
+			has_country_modifier = luddite
+			has_country_modifier = great_statesman
+			has_country_modifier = backroom_boy
+			has_country_modifier = great_reformer
+			has_country_modifier = gauche_buffoon
+			has_country_modifier = administrative_genius
+			has_country_modifier = visionary_thinker
+			has_country_modifier = competent_placeholder
+			has_country_modifier = imperious_autocrat
+			has_country_modifier = prince_of_terror
+			has_country_modifier = efficient_sociopath
+			has_country_modifier = pig_headed_isolationist
+			has_country_modifier = ambitious_union_boss
+			has_country_modifier = dour_economist
+			has_country_modifier = power_vacuum
+			has_country_flag = minister_found
+		}
+		OR = {
 			government = proletarian_dictatorship
-            government = presidential_dictatorship
-            government = fascist_dictatorship
-        }
-    }
+			government = presidential_dictatorship
+			government = fascist_dictatorship
+		}
+	}
 
-    mean_time_to_happen = {
-        days = 14
-    }
+	mean_time_to_happen = {
+		days = 14
+	}
 
-    immediate = {
-        set_country_flag = minister_found
-    }
+	immediate = {
+		set_country_flag = minister_found
+	}
 
-    option = {
-        name = "I hope they're a good one..."
-        random_list = {
+	option = {
+		name = "I hope they're a good one..."
+		set_country_flag = hidden_tooltip
+		random_owned = {
+			limit = { has_country_flag = hidden_tooltip }
+			remove_country_modifier = expert_diplomat
+			remove_country_modifier = successful_industrialist
+			remove_country_modifier = ivory_tower_intellectual
+			remove_country_modifier = man_of_the_people
+			remove_country_modifier = landed_gentleman
+			remove_country_modifier = military_man
+			remove_country_modifier = lord_admiral
+			remove_country_modifier = raving_loon
+			remove_country_modifier = luddite
+			remove_country_modifier = great_statesman
+			remove_country_modifier = backroom_boy
+			remove_country_modifier = great_reformer
+			remove_country_modifier = gauche_buffoon
+			remove_country_modifier = administrative_genius
+			remove_country_modifier = visionary_thinker
+			remove_country_modifier = competent_placeholder
+			remove_country_modifier = imperious_autocrat
+			remove_country_modifier = prince_of_terror
+			remove_country_modifier = efficient_sociopath
+			remove_country_modifier = pig_headed_isolationist
+			remove_country_modifier = ambitious_union_boss
+			remove_country_modifier = dour_economist
+		}
+		clr_country_flag = hidden_tooltip
+		random_list = {
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = expert_diplomat
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = successful_industrialist
 					duration = 3650
 				}
-				clr_country_flag = minister_found
+				random_owned = {
+					limit = { owner = { civilized = no } }
+					owner = {
+						remove_country_modifier = successful_industrialist
+						add_country_modifier = {
+							name = competent_placeholder
+							duration = 3650
+						}
+					}
+				}
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = ivory_tower_intellectual
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = man_of_the_people
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = landed_gentleman
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = military_man
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = lord_admiral
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = raving_loon
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = luddite
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = great_statesman
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = backroom_boy
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = great_reformer
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = gauche_buffoon
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = administrative_genius
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = visionary_thinker
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = competent_placeholder
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = imperious_autocrat
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = prince_of_terror
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = efficient_sociopath
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = pig_headed_isolationist
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = ambitious_union_boss
 					duration = 3650
 				}
-				clr_country_flag = minister_found
+				random_owned = {
+					limit = { owner = { trade_unions = no_trade_unions } }
+					owner = {
+						remove_country_modifier = ambitious_union_boss
+						add_country_modifier = {
+							name = competent_placeholder
+							duration = 3650
+						}
+					}
+				}
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = dour_economist
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 		}
-    }
+		clr_country_flag = minister_found
+	}
 }
 
 country_event = {
-    id = 100050120
-    title = "Great Leader Assassinated"
-    desc = "Our Great Leader has been murdered!"
-    news = yes
-    news_title = "EVTNAME20006_NEWS_TITLE"
-    news_desc_long = "EVTDESC20006_NEWS_LONG"
-    news_desc_medium = "EVTDESC20006_NEWS_MEDIUM"
-    news_desc_short = "EVTDESC20006_NEWS_SHORT"
-    picture = "assassination"
-    trigger = {
+	id = 100050120
+	title = "Great Leader Assassinated"
+	desc = "Our Great Leader has been murdered!"
+	news = yes
+	news_title = "EVTNAME20006_NEWS_TITLE"
+	news_desc_long = "EVTDESC20006_NEWS_LONG"
+	news_desc_medium = "EVTDESC20006_NEWS_MEDIUM"
+	news_desc_short = "EVTDESC20006_NEWS_SHORT"
+	picture = "assassination"
+	trigger = {
 		ai = no
-        OR = {
-            has_country_modifier = expert_diplomat
-            has_country_modifier = successful_industrialist
-            has_country_modifier = ivory_tower_intellectual
-            has_country_modifier = man_of_the_people
-            has_country_modifier = landed_gentleman
-            has_country_modifier = military_man
-            has_country_modifier = lord_admiral
-            has_country_modifier = raving_loon
-            has_country_modifier = luddite
-            has_country_modifier = great_statesman
-            has_country_modifier = backroom_boy
-            has_country_modifier = great_reformer
-            has_country_modifier = gauche_buffoon
-            has_country_modifier = administrative_genius
-            has_country_modifier = visionary_thinker
-            has_country_modifier = competent_placeholder
-            has_country_modifier = imperious_autocrat
-            has_country_modifier = prince_of_terror
-            has_country_modifier = efficient_sociopath
-            has_country_modifier = pig_headed_isolationist
-            has_country_modifier = ambitious_union_boss
-            has_country_modifier = dour_economist
-        }
-        average_militancy = 5
-        OR = {
-            government = proletarian_dictatorship
-            government = presidential_dictatorship
-            government = fascist_dictatorship
-        }
-    }
+		OR = {
+			has_country_modifier = expert_diplomat
+			has_country_modifier = successful_industrialist
+			has_country_modifier = ivory_tower_intellectual
+			has_country_modifier = man_of_the_people
+			has_country_modifier = landed_gentleman
+			has_country_modifier = military_man
+			has_country_modifier = lord_admiral
+			has_country_modifier = raving_loon
+			has_country_modifier = luddite
+			has_country_modifier = great_statesman
+			has_country_modifier = backroom_boy
+			has_country_modifier = great_reformer
+			has_country_modifier = gauche_buffoon
+			has_country_modifier = administrative_genius
+			has_country_modifier = visionary_thinker
+			has_country_modifier = competent_placeholder
+			has_country_modifier = imperious_autocrat
+			has_country_modifier = prince_of_terror
+			has_country_modifier = efficient_sociopath
+			has_country_modifier = pig_headed_isolationist
+			has_country_modifier = ambitious_union_boss
+			has_country_modifier = dour_economist
+		}
+		average_militancy = 5
+		OR = {
+			government = proletarian_dictatorship
+			government = presidential_dictatorship
+			government = fascist_dictatorship
+		}
+	}
 
-    mean_time_to_happen = {
-        months = 48
-    }
+	mean_time_to_happen = {
+		months = 48
+	}
 
-    option = {
-        name = "A tragedy!"
-        remove_country_modifier = expert_diplomat
-        remove_country_modifier = successful_industrialist
-        remove_country_modifier = ivory_tower_intellectual
-        remove_country_modifier = man_of_the_people
-        remove_country_modifier = landed_gentleman
-        remove_country_modifier = military_man
-        remove_country_modifier = lord_admiral
-        remove_country_modifier = raving_loon
-        remove_country_modifier = luddite
-        remove_country_modifier = great_statesman
-        remove_country_modifier = backroom_boy
-        remove_country_modifier = great_reformer
-        remove_country_modifier = gauche_buffoon
-        remove_country_modifier = administrative_genius
-        remove_country_modifier = visionary_thinker
-        remove_country_modifier = competent_placeholder
-        remove_country_modifier = imperious_autocrat
-        remove_country_modifier = prince_of_terror
-        remove_country_modifier = efficient_sociopath
-        remove_country_modifier = pig_headed_isolationist
-        remove_country_modifier = ambitious_union_boss
-        remove_country_modifier = dour_economist
-        add_country_modifier = {
-            name = national_confusion
-            duration = 365
-        }
-        add_country_modifier = {
-            name = power_vacuum
-            duration = 365
-        }
-    }
+	option = {
+		name = "A tragedy!"
+		remove_country_modifier = expert_diplomat
+		remove_country_modifier = successful_industrialist
+		remove_country_modifier = ivory_tower_intellectual
+		remove_country_modifier = man_of_the_people
+		remove_country_modifier = landed_gentleman
+		remove_country_modifier = military_man
+		remove_country_modifier = lord_admiral
+		remove_country_modifier = raving_loon
+		remove_country_modifier = luddite
+		remove_country_modifier = great_statesman
+		remove_country_modifier = backroom_boy
+		remove_country_modifier = great_reformer
+		remove_country_modifier = gauche_buffoon
+		remove_country_modifier = administrative_genius
+		remove_country_modifier = visionary_thinker
+		remove_country_modifier = competent_placeholder
+		remove_country_modifier = imperious_autocrat
+		remove_country_modifier = prince_of_terror
+		remove_country_modifier = efficient_sociopath
+		remove_country_modifier = pig_headed_isolationist
+		remove_country_modifier = ambitious_union_boss
+		remove_country_modifier = dour_economist
+		add_country_modifier = {
+			name = national_confusion
+			duration = 365
+		}
+		add_country_modifier = {
+			name = power_vacuum
+			duration = 365
+		}
+	}
 }
 
 
@@ -1600,727 +684,268 @@ country_event = {
 
 
 country_event = {
-    id = 100060001
-    title = "First Minister Appointed"
-    desc = "A new first minister has been appointed."
-    picture = "danishgovernment"
-    trigger = {
+	id = 100060001
+	title = "First Minister Appointed"
+	desc = "A new first minister has been appointed."
+	picture = "danishgovernment"
+	trigger = {
 		ai = no
-        NOT = {
-            has_country_modifier = expert_diplomat
-            has_country_modifier = successful_industrialist
-            has_country_modifier = ivory_tower_intellectual
-            has_country_modifier = man_of_the_people
-            has_country_modifier = landed_gentleman
-            has_country_modifier = military_man
-            has_country_modifier = lord_admiral
-            has_country_modifier = raving_loon
-            has_country_modifier = luddite
-            has_country_modifier = great_statesman
-            has_country_modifier = backroom_boy
-            has_country_modifier = great_reformer
-            has_country_modifier = gauche_buffoon
-            has_country_modifier = administrative_genius
-            has_country_modifier = visionary_thinker
-            has_country_modifier = competent_placeholder
-            has_country_modifier = imperious_autocrat
-            has_country_modifier = prince_of_terror
-            has_country_modifier = efficient_sociopath
-            has_country_modifier = pig_headed_isolationist
-            has_country_modifier = ambitious_union_boss
-            has_country_modifier = dour_economist
-            has_country_modifier = otto_von_bismarck
-            has_country_modifier = louis_napoleon_iii
-            has_country_modifier = dom_pedro_ii
-            has_country_modifier = power_vacuum
-            has_country_flag = minister_found
-
-        }
-        OR = {
-            has_country_flag = liberal_election_win
-            has_country_flag = anarcho_liberal_win
-        }
-        OR = {
+		NOT = {
+			has_country_modifier = expert_diplomat
+			has_country_modifier = successful_industrialist
+			has_country_modifier = ivory_tower_intellectual
+			has_country_modifier = man_of_the_people
+			has_country_modifier = landed_gentleman
+			has_country_modifier = military_man
+			has_country_modifier = lord_admiral
+			has_country_modifier = raving_loon
+			has_country_modifier = luddite
+			has_country_modifier = great_statesman
+			has_country_modifier = backroom_boy
+			has_country_modifier = great_reformer
+			has_country_modifier = gauche_buffoon
+			has_country_modifier = administrative_genius
+			has_country_modifier = visionary_thinker
+			has_country_modifier = competent_placeholder
+			has_country_modifier = imperious_autocrat
+			has_country_modifier = prince_of_terror
+			has_country_modifier = efficient_sociopath
+			has_country_modifier = pig_headed_isolationist
+			has_country_modifier = ambitious_union_boss
+			has_country_modifier = dour_economist
+			has_country_modifier = otto_von_bismarck
+			has_country_modifier = louis_napoleon_iii
+			has_country_modifier = dom_pedro_ii
+			has_country_modifier = power_vacuum
+			has_country_flag = minister_found
+		}
+		OR = {
+			has_country_flag = liberal_election_win
+			has_country_flag = anarcho_liberal_win
+		}
+		OR = {
 			government = radical_republic
 			government = constitutional_empire
-            government = hms_government
-            government = democracy
-        }
-    }
+			government = hms_government
+			government = democracy
+		}
+	}
 
-    mean_time_to_happen = {
-        days = 14
-    }
+	mean_time_to_happen = {
+		days = 14
+	}
 
-    immediate = {
-        set_country_flag = minister_found
-    }
+	immediate = {
+		set_country_flag = minister_found
+	}
 
-    option = {
-        name = "I hope they're a good one..."
-        random_list = {
+	option = {
+		name = "I hope they're a good one..."
+		set_country_flag = hidden_tooltip
+		random_owned = {
+			limit = { has_country_flag = hidden_tooltip }
+			remove_country_modifier = expert_diplomat
+			remove_country_modifier = successful_industrialist
+			remove_country_modifier = ivory_tower_intellectual
+			remove_country_modifier = man_of_the_people
+			remove_country_modifier = landed_gentleman
+			remove_country_modifier = military_man
+			remove_country_modifier = lord_admiral
+			remove_country_modifier = raving_loon
+			remove_country_modifier = luddite
+			remove_country_modifier = great_statesman
+			remove_country_modifier = backroom_boy
+			remove_country_modifier = great_reformer
+			remove_country_modifier = gauche_buffoon
+			remove_country_modifier = administrative_genius
+			remove_country_modifier = visionary_thinker
+			remove_country_modifier = competent_placeholder
+			remove_country_modifier = imperious_autocrat
+			remove_country_modifier = prince_of_terror
+			remove_country_modifier = efficient_sociopath
+			remove_country_modifier = pig_headed_isolationist
+			remove_country_modifier = ambitious_union_boss
+			remove_country_modifier = dour_economist
+		}
+		clr_country_flag = hidden_tooltip
+		random_list = {
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = expert_diplomat
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = successful_industrialist
 					duration = 3650
 				}
-				clr_country_flag = minister_found
+				random_owned = {
+					limit = { owner = { civilized = no } }
+					owner = {
+						remove_country_modifier = successful_industrialist
+						add_country_modifier = {
+							name = competent_placeholder
+							duration = 3650
+						}
+					}
+				}
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = ivory_tower_intellectual
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = man_of_the_people
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = landed_gentleman
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = military_man
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = lord_admiral
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = raving_loon
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = luddite
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = great_statesman
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = backroom_boy
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = great_reformer
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = gauche_buffoon
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = administrative_genius
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = visionary_thinker
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = competent_placeholder
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = imperious_autocrat
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = prince_of_terror
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = efficient_sociopath
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = pig_headed_isolationist
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = ambitious_union_boss
 					duration = 3650
 				}
-				clr_country_flag = minister_found
+				random_owned = {
+					limit = { owner = { trade_unions = no_trade_unions } }
+					owner = {
+						remove_country_modifier = ambitious_union_boss
+						add_country_modifier = {
+							name = competent_placeholder
+							duration = 3650
+						}
+					}
+				}
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = dour_economist
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 		}
-    }
+		clr_country_flag = minister_found
+	}
 }
 
 
@@ -2329,726 +954,268 @@ country_event = {
 
 
 country_event = {
-    id = 100070001
-    title = "First Minister Appointed"
-    desc = "A new first minister has been appointed."
-    picture = "danishgovernment"
-    trigger = {
+	id = 100070001
+	title = "First Minister Appointed"
+	desc = "A new first minister has been appointed."
+	picture = "danishgovernment"
+	trigger = {
 		ai = no
-        NOT = {
-            has_country_modifier = expert_diplomat
-            has_country_modifier = successful_industrialist
-            has_country_modifier = ivory_tower_intellectual
-            has_country_modifier = man_of_the_people
-            has_country_modifier = landed_gentleman
-            has_country_modifier = military_man
-            has_country_modifier = lord_admiral
-            has_country_modifier = raving_loon
-            has_country_modifier = luddite
-            has_country_modifier = great_statesman
-            has_country_modifier = backroom_boy
-            has_country_modifier = great_reformer
-            has_country_modifier = gauche_buffoon
-            has_country_modifier = administrative_genius
-            has_country_modifier = visionary_thinker
-            has_country_modifier = competent_placeholder
-            has_country_modifier = imperious_autocrat
-            has_country_modifier = prince_of_terror
-            has_country_modifier = efficient_sociopath
-            has_country_modifier = pig_headed_isolationist
-            has_country_modifier = ambitious_union_boss
-            has_country_modifier = dour_economist
-            has_country_modifier = otto_von_bismarck
-            has_country_modifier = louis_napoleon_iii
-            has_country_modifier = dom_pedro_ii
-            has_country_modifier = power_vacuum
-            has_country_flag = minister_found
-        }
-        OR = {
-            has_country_flag = tory_election_win
-            has_country_flag = fascist_election_win
-            has_country_flag = reactionary_election_win
-        }
-        OR = {
+		NOT = {
+			has_country_modifier = expert_diplomat
+			has_country_modifier = successful_industrialist
+			has_country_modifier = ivory_tower_intellectual
+			has_country_modifier = man_of_the_people
+			has_country_modifier = landed_gentleman
+			has_country_modifier = military_man
+			has_country_modifier = lord_admiral
+			has_country_modifier = raving_loon
+			has_country_modifier = luddite
+			has_country_modifier = great_statesman
+			has_country_modifier = backroom_boy
+			has_country_modifier = great_reformer
+			has_country_modifier = gauche_buffoon
+			has_country_modifier = administrative_genius
+			has_country_modifier = visionary_thinker
+			has_country_modifier = competent_placeholder
+			has_country_modifier = imperious_autocrat
+			has_country_modifier = prince_of_terror
+			has_country_modifier = efficient_sociopath
+			has_country_modifier = pig_headed_isolationist
+			has_country_modifier = ambitious_union_boss
+			has_country_modifier = dour_economist
+			has_country_modifier = otto_von_bismarck
+			has_country_modifier = louis_napoleon_iii
+			has_country_modifier = dom_pedro_ii
+			has_country_modifier = power_vacuum
+			has_country_flag = minister_found
+		}
+		OR = {
+			has_country_flag = tory_election_win
+			has_country_flag = fascist_election_win
+			has_country_flag = reactionary_election_win
+		}
+		OR = {
 			government = constitutional_empire
-            government = hms_government
-            government = democracy
-        }
-    }
+			government = hms_government
+			government = democracy
+		}
+	}
 
-    mean_time_to_happen = {
-        days = 14
-    }
+	mean_time_to_happen = {
+		days = 14
+	}
 
-    immediate = {
-        set_country_flag = minister_found
-    }
+	immediate = {
+		set_country_flag = minister_found
+	}
 
-    option = {
-        name = "I hope they're a good one..."
-        random_list = {
+	option = {
+		name = "I hope they're a good one..."
+		set_country_flag = hidden_tooltip
+		random_owned = {
+			limit = { has_country_flag = hidden_tooltip }
+			remove_country_modifier = expert_diplomat
+			remove_country_modifier = successful_industrialist
+			remove_country_modifier = ivory_tower_intellectual
+			remove_country_modifier = man_of_the_people
+			remove_country_modifier = landed_gentleman
+			remove_country_modifier = military_man
+			remove_country_modifier = lord_admiral
+			remove_country_modifier = raving_loon
+			remove_country_modifier = luddite
+			remove_country_modifier = great_statesman
+			remove_country_modifier = backroom_boy
+			remove_country_modifier = great_reformer
+			remove_country_modifier = gauche_buffoon
+			remove_country_modifier = administrative_genius
+			remove_country_modifier = visionary_thinker
+			remove_country_modifier = competent_placeholder
+			remove_country_modifier = imperious_autocrat
+			remove_country_modifier = prince_of_terror
+			remove_country_modifier = efficient_sociopath
+			remove_country_modifier = pig_headed_isolationist
+			remove_country_modifier = ambitious_union_boss
+			remove_country_modifier = dour_economist
+		}
+		clr_country_flag = hidden_tooltip
+		random_list = {
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = expert_diplomat
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = successful_industrialist
 					duration = 3650
 				}
-				clr_country_flag = minister_found
+				random_owned = {
+					limit = { owner = { civilized = no } }
+					owner = {
+						remove_country_modifier = successful_industrialist
+						add_country_modifier = {
+							name = competent_placeholder
+							duration = 3650
+						}
+					}
+				}
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = ivory_tower_intellectual
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = man_of_the_people
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = landed_gentleman
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = military_man
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = lord_admiral
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = raving_loon
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = luddite
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = great_statesman
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = backroom_boy
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = great_reformer
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = gauche_buffoon
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = administrative_genius
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = visionary_thinker
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = competent_placeholder
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = imperious_autocrat
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = prince_of_terror
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = efficient_sociopath
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = pig_headed_isolationist
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = ambitious_union_boss
 					duration = 3650
 				}
-				clr_country_flag = minister_found
+				random_owned = {
+					limit = { owner = { trade_unions = no_trade_unions } }
+					owner = {
+						remove_country_modifier = ambitious_union_boss
+						add_country_modifier = {
+							name = competent_placeholder
+							duration = 3650
+						}
+					}
+				}
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = dour_economist
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 		}
-    }
+		clr_country_flag = minister_found
+	}
 }
 
 
@@ -3056,894 +1223,483 @@ country_event = {
 
 
 country_event = {
-    id = 100080001
-    title = "First Minister Appointed"
-    desc = "A new first minister has been appointed."
-    picture = "danishgovernment"
-    trigger = {
+	id = 100080001
+	title = "First Minister Appointed"
+	desc = "A new first minister has been appointed."
+	picture = "danishgovernment"
+	trigger = {
 		ai = no
-        NOT = {
-            has_country_modifier = expert_diplomat
-            has_country_modifier = successful_industrialist
-            has_country_modifier = ivory_tower_intellectual
-            has_country_modifier = man_of_the_people
-            has_country_modifier = landed_gentleman
-            has_country_modifier = military_man
-            has_country_modifier = lord_admiral
-            has_country_modifier = raving_loon
-            has_country_modifier = luddite
-            has_country_modifier = great_statesman
-            has_country_modifier = backroom_boy
-            has_country_modifier = great_reformer
-            has_country_modifier = gauche_buffoon
-            has_country_modifier = administrative_genius
-            has_country_modifier = visionary_thinker
-            has_country_modifier = competent_placeholder
-            has_country_modifier = imperious_autocrat
-            has_country_modifier = prince_of_terror
-            has_country_modifier = efficient_sociopath
-            has_country_modifier = pig_headed_isolationist
-            has_country_modifier = ambitious_union_boss
-            has_country_modifier = dour_economist
-            has_country_modifier = otto_von_bismarck
-            has_country_modifier = louis_napoleon_iii
-            has_country_modifier = dom_pedro_ii
-            has_country_modifier = power_vacuum
-            has_country_flag = minister_found
-        }
-        OR = {
-            has_country_flag = socialist_election_win
-            has_country_flag = communist_election_win
-        }
-        OR = {
+		NOT = {
+			has_country_modifier = expert_diplomat
+			has_country_modifier = successful_industrialist
+			has_country_modifier = ivory_tower_intellectual
+			has_country_modifier = man_of_the_people
+			has_country_modifier = landed_gentleman
+			has_country_modifier = military_man
+			has_country_modifier = lord_admiral
+			has_country_modifier = raving_loon
+			has_country_modifier = luddite
+			has_country_modifier = great_statesman
+			has_country_modifier = backroom_boy
+			has_country_modifier = great_reformer
+			has_country_modifier = gauche_buffoon
+			has_country_modifier = administrative_genius
+			has_country_modifier = visionary_thinker
+			has_country_modifier = competent_placeholder
+			has_country_modifier = imperious_autocrat
+			has_country_modifier = prince_of_terror
+			has_country_modifier = efficient_sociopath
+			has_country_modifier = pig_headed_isolationist
+			has_country_modifier = ambitious_union_boss
+			has_country_modifier = dour_economist
+			has_country_modifier = otto_von_bismarck
+			has_country_modifier = louis_napoleon_iii
+			has_country_modifier = dom_pedro_ii
+			has_country_modifier = power_vacuum
+			has_country_flag = minister_found
+		}
+		OR = {
+			has_country_flag = socialist_election_win
+			has_country_flag = communist_election_win
+		}
+		OR = {
 			government = radical_republic
 			government = constitutional_empire
-            government = hms_government
-            government = democracy
-        }
-    }
+			government = hms_government
+			government = democracy
+		}
+	}
 
-    mean_time_to_happen = {
-        days = 14
-    }
+	mean_time_to_happen = {
+		days = 14
+	}
 
-    immediate = {
-        set_country_flag = minister_found
-    }
+	immediate = {
+		set_country_flag = minister_found
+	}
 
-    option = {
-        name = "I hope they're a good one..."
-        random_list = {
+	option = {
+		name = "I hope they're a good one..."
+		set_country_flag = hidden_tooltip
+		random_owned = {
+			limit = { has_country_flag = hidden_tooltip }
+			remove_country_modifier = expert_diplomat
+			remove_country_modifier = successful_industrialist
+			remove_country_modifier = ivory_tower_intellectual
+			remove_country_modifier = man_of_the_people
+			remove_country_modifier = landed_gentleman
+			remove_country_modifier = military_man
+			remove_country_modifier = lord_admiral
+			remove_country_modifier = raving_loon
+			remove_country_modifier = luddite
+			remove_country_modifier = great_statesman
+			remove_country_modifier = backroom_boy
+			remove_country_modifier = great_reformer
+			remove_country_modifier = gauche_buffoon
+			remove_country_modifier = administrative_genius
+			remove_country_modifier = visionary_thinker
+			remove_country_modifier = competent_placeholder
+			remove_country_modifier = imperious_autocrat
+			remove_country_modifier = prince_of_terror
+			remove_country_modifier = efficient_sociopath
+			remove_country_modifier = pig_headed_isolationist
+			remove_country_modifier = ambitious_union_boss
+			remove_country_modifier = dour_economist
+		}
+		clr_country_flag = hidden_tooltip
+		random_list = {
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = expert_diplomat
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = successful_industrialist
 					duration = 3650
 				}
-				clr_country_flag = minister_found
+				random_owned = {
+					limit = { owner = { civilized = no } }
+					owner = {
+						remove_country_modifier = successful_industrialist
+						add_country_modifier = {
+							name = competent_placeholder
+							duration = 3650
+						}
+					}
+				}
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = ivory_tower_intellectual
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = man_of_the_people
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = landed_gentleman
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = military_man
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = lord_admiral
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = raving_loon
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = luddite
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = great_statesman
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = backroom_boy
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = great_reformer
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = gauche_buffoon
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = administrative_genius
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = visionary_thinker
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = competent_placeholder
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = imperious_autocrat
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = prince_of_terror
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = efficient_sociopath
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = pig_headed_isolationist
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = ambitious_union_boss
 					duration = 3650
 				}
-				clr_country_flag = minister_found
+				random_owned = {
+					limit = { owner = { trade_unions = no_trade_unions } }
+					owner = {
+						remove_country_modifier = ambitious_union_boss
+						add_country_modifier = {
+							name = competent_placeholder
+							duration = 3650
+						}
+					}
+				}
 			}
 			# Audax Validator "." Ignore_NEXT
 			4.5 = {
-				remove_country_modifier = expert_diplomat
-				remove_country_modifier = successful_industrialist
-				remove_country_modifier = ivory_tower_intellectual
-				remove_country_modifier = man_of_the_people
-				remove_country_modifier = landed_gentleman
-				remove_country_modifier = military_man
-				remove_country_modifier = lord_admiral
-				remove_country_modifier = raving_loon
-				remove_country_modifier = luddite
-				remove_country_modifier = great_statesman
-				remove_country_modifier = backroom_boy
-				remove_country_modifier = great_reformer
-				remove_country_modifier = gauche_buffoon
-				remove_country_modifier = administrative_genius
-				remove_country_modifier = visionary_thinker
-				remove_country_modifier = competent_placeholder
-				remove_country_modifier = imperious_autocrat
-				remove_country_modifier = prince_of_terror
-				remove_country_modifier = efficient_sociopath
-				remove_country_modifier = pig_headed_isolationist
-				remove_country_modifier = ambitious_union_boss
-				remove_country_modifier = dour_economist
 				add_country_modifier = {
 					name = dour_economist
 					duration = 3650
 				}
-				clr_country_flag = minister_found
 			}
 		}
-    }
+		clr_country_flag = minister_found
+	}
 }
 
 country_event = {
-    id = 100080123
-    title = "First Minister Dies in Office"
-    desc = "Our hardworking First minister was found dead at his desk this morning."
-    picture = "danishgovernment"
-    trigger = {
+	id = 100080123
+	title = "First Minister Dies in Office"
+	desc = "Our hardworking First minister was found dead at his desk this morning."
+	picture = "danishgovernment"
+	trigger = {
 		ai = no
-        NOT = {
-            government = proletarian_dictatorship
-            government = presidential_dictatorship
-            government = fascist_dictatorship
-        }
-        OR = {
-            has_country_modifier = expert_diplomat
-            has_country_modifier = successful_industrialist
-            has_country_modifier = ivory_tower_intellectual
-            has_country_modifier = man_of_the_people
-            has_country_modifier = landed_gentleman
-            has_country_modifier = military_man
-            has_country_modifier = lord_admiral
-            has_country_modifier = raving_loon
-            has_country_modifier = luddite
-            has_country_modifier = great_statesman
-            has_country_modifier = backroom_boy
-            has_country_modifier = great_reformer
-            has_country_modifier = gauche_buffoon
-            has_country_modifier = administrative_genius
-            has_country_modifier = visionary_thinker
-            has_country_modifier = competent_placeholder
-            has_country_modifier = imperious_autocrat
-            has_country_modifier = prince_of_terror
-            has_country_modifier = efficient_sociopath
-            has_country_modifier = pig_headed_isolationist
-            has_country_modifier = ambitious_union_boss
-            has_country_modifier = dour_economist
-         }
+		NOT = {
+			government = proletarian_dictatorship
+			government = presidential_dictatorship
+			government = fascist_dictatorship
+		}
+		OR = {
+			has_country_modifier = expert_diplomat
+			has_country_modifier = successful_industrialist
+			has_country_modifier = ivory_tower_intellectual
+			has_country_modifier = man_of_the_people
+			has_country_modifier = landed_gentleman
+			has_country_modifier = military_man
+			has_country_modifier = lord_admiral
+			has_country_modifier = raving_loon
+			has_country_modifier = luddite
+			has_country_modifier = great_statesman
+			has_country_modifier = backroom_boy
+			has_country_modifier = great_reformer
+			has_country_modifier = gauche_buffoon
+			has_country_modifier = administrative_genius
+			has_country_modifier = visionary_thinker
+			has_country_modifier = competent_placeholder
+			has_country_modifier = imperious_autocrat
+			has_country_modifier = prince_of_terror
+			has_country_modifier = efficient_sociopath
+			has_country_modifier = pig_headed_isolationist
+			has_country_modifier = ambitious_union_boss
+			has_country_modifier = dour_economist
+		}
 
-    }
+	}
 
-    mean_time_to_happen = {
-        months = 1200
-    }
+	mean_time_to_happen = {
+		months = 1200
+	}
 
-    option = {
-        name = "He will be sorely missed."
-        remove_country_modifier = expert_diplomat
-        remove_country_modifier = successful_industrialist
-        remove_country_modifier = ivory_tower_intellectual
-        remove_country_modifier = man_of_the_people
-        remove_country_modifier = landed_gentleman
-        remove_country_modifier = military_man
-        remove_country_modifier = lord_admiral
-        remove_country_modifier = raving_loon
-        remove_country_modifier = luddite
-        remove_country_modifier = great_statesman
-        remove_country_modifier = backroom_boy
-        remove_country_modifier = great_reformer
-        remove_country_modifier = gauche_buffoon
-        remove_country_modifier = administrative_genius
-        remove_country_modifier = visionary_thinker
-        remove_country_modifier = competent_placeholder
-        remove_country_modifier = imperious_autocrat
-        remove_country_modifier = prince_of_terror
-        remove_country_modifier = efficient_sociopath
-        remove_country_modifier = pig_headed_isolationist
-        remove_country_modifier = ambitious_union_boss
-        remove_country_modifier = dour_economist
-    }
+	option = {
+		name = "He will be sorely missed."
+		remove_country_modifier = expert_diplomat
+		remove_country_modifier = successful_industrialist
+		remove_country_modifier = ivory_tower_intellectual
+		remove_country_modifier = man_of_the_people
+		remove_country_modifier = landed_gentleman
+		remove_country_modifier = military_man
+		remove_country_modifier = lord_admiral
+		remove_country_modifier = raving_loon
+		remove_country_modifier = luddite
+		remove_country_modifier = great_statesman
+		remove_country_modifier = backroom_boy
+		remove_country_modifier = great_reformer
+		remove_country_modifier = gauche_buffoon
+		remove_country_modifier = administrative_genius
+		remove_country_modifier = visionary_thinker
+		remove_country_modifier = competent_placeholder
+		remove_country_modifier = imperious_autocrat
+		remove_country_modifier = prince_of_terror
+		remove_country_modifier = efficient_sociopath
+		remove_country_modifier = pig_headed_isolationist
+		remove_country_modifier = ambitious_union_boss
+		remove_country_modifier = dour_economist
+	}
 }
 
 country_event = {
-    id = 100080124
-    title = "First Minister Committed"
-    desc = "After he declared Thursdays to be Compulsory Pie-wearing day, our First minister has been 'retired'..."
-    picture = "danishgovernment"
-    trigger = {
+	id = 100080124
+	title = "First Minister Ousted"
+	desc = "After he declared Thursdays to be a compulsory Pie-wearing day, our First minister has been 'retired' from their duties"
+	picture = "danishgovernment"
+	trigger = {
 		ai = no
-        NOT = {
-            government = proletarian_dictatorship
-            government = presidential_dictatorship
-            government = fascist_dictatorship
-        }
-        has_country_modifier = raving_loon
-    }
+		NOT = {
+			government = proletarian_dictatorship
+			government = presidential_dictatorship
+			government = fascist_dictatorship
+		}
+		has_country_modifier = raving_loon
+	}
 
-    mean_time_to_happen = {
-        months = 120
-    }
+	mean_time_to_happen = {
+		months = 120
+	}
 
-    option = {
-        name = "He will be sorely missed."
-        prestige = -10
-        remove_country_modifier = raving_loon
-    }
+	option = {
+		name = "He will be sorely missed."
+		prestige = -10
+		remove_country_modifier = raving_loon
+	}
 }
 
 country_event = {
-    id = 100080125
-    title = "Great Leader Dies in Office"
-    desc = "Our hardworking Great Leader was found dead at his chateaux this morning, by the six young ladies who were in his care..."
-    picture = "danishgovernment"
-    trigger = {
+	id = 100080125
+	title = "Great Leader Dies in Office"
+	desc = "Our hardworking Great Leader was found dead at his chateaux this morning, by the six young ladies who were in his care..."
+	picture = "danishgovernment"
+	trigger = {
 		ai = no
-        OR = {
-            government = proletarian_dictatorship
-            government = presidential_dictatorship
-            government = fascist_dictatorship
-        }
-        OR = {
-            has_country_modifier = expert_diplomat
-            has_country_modifier = successful_industrialist
-            has_country_modifier = ivory_tower_intellectual
-            has_country_modifier = man_of_the_people
-            has_country_modifier = landed_gentleman
-            has_country_modifier = military_man
-            has_country_modifier = lord_admiral
-            has_country_modifier = raving_loon
-            has_country_modifier = luddite
-            has_country_modifier = great_statesman
-            has_country_modifier = backroom_boy
-            has_country_modifier = great_reformer
-            has_country_modifier = gauche_buffoon
-            has_country_modifier = administrative_genius
-            has_country_modifier = visionary_thinker
-            has_country_modifier = competent_placeholder
-            has_country_modifier = imperious_autocrat
-            has_country_modifier = prince_of_terror
-            has_country_modifier = efficient_sociopath
-            has_country_modifier = pig_headed_isolationist
-            has_country_modifier = ambitious_union_boss
-            has_country_modifier = dour_economist
-        }
+		OR = {
+			government = proletarian_dictatorship
+			government = presidential_dictatorship
+			government = fascist_dictatorship
+		}
+		OR = {
+			has_country_modifier = expert_diplomat
+			has_country_modifier = successful_industrialist
+			has_country_modifier = ivory_tower_intellectual
+			has_country_modifier = man_of_the_people
+			has_country_modifier = landed_gentleman
+			has_country_modifier = military_man
+			has_country_modifier = lord_admiral
+			has_country_modifier = raving_loon
+			has_country_modifier = luddite
+			has_country_modifier = great_statesman
+			has_country_modifier = backroom_boy
+			has_country_modifier = great_reformer
+			has_country_modifier = gauche_buffoon
+			has_country_modifier = administrative_genius
+			has_country_modifier = visionary_thinker
+			has_country_modifier = competent_placeholder
+			has_country_modifier = imperious_autocrat
+			has_country_modifier = prince_of_terror
+			has_country_modifier = efficient_sociopath
+			has_country_modifier = pig_headed_isolationist
+			has_country_modifier = ambitious_union_boss
+			has_country_modifier = dour_economist
+		}
+	}
 
-    }
+	mean_time_to_happen = {
+		months = 1200
+	}
 
-    mean_time_to_happen = {
-        months = 1200
-    }
+	option = {
+		name = "The public doesn't need to know."
+		random_owned = {
+			limit = {
+				OR = {
+					is_core = THIS
+					is_capital = yes
+				}
+			}
+			any_pop = { consciousness = 2 }
+		}
+		remove_country_modifier = expert_diplomat
+		remove_country_modifier = successful_industrialist
+		remove_country_modifier = ivory_tower_intellectual
+		remove_country_modifier = man_of_the_people
+		remove_country_modifier = landed_gentleman
+		remove_country_modifier = military_man
+		remove_country_modifier = lord_admiral
+		remove_country_modifier = raving_loon
+		remove_country_modifier = luddite
+		remove_country_modifier = great_statesman
+		remove_country_modifier = backroom_boy
+		remove_country_modifier = great_reformer
+		remove_country_modifier = gauche_buffoon
+		remove_country_modifier = administrative_genius
+		remove_country_modifier = visionary_thinker
+		remove_country_modifier = competent_placeholder
+		remove_country_modifier = imperious_autocrat
+		remove_country_modifier = prince_of_terror
+		remove_country_modifier = efficient_sociopath
+		remove_country_modifier = pig_headed_isolationist
+		remove_country_modifier = ambitious_union_boss
+		remove_country_modifier = dour_economist
+		add_country_modifier = {
+			name = power_vacuum
+			duration = 365
+		}
+	}
 
-    option = {
-        name = "Truly, he loved his people too much. Literally, in this case."
-        remove_country_modifier = expert_diplomat
-        remove_country_modifier = successful_industrialist
-        remove_country_modifier = ivory_tower_intellectual
-        remove_country_modifier = man_of_the_people
-        remove_country_modifier = landed_gentleman
-        remove_country_modifier = military_man
-        remove_country_modifier = lord_admiral
-        remove_country_modifier = raving_loon
-        remove_country_modifier = luddite
-        remove_country_modifier = great_statesman
-        remove_country_modifier = backroom_boy
-        remove_country_modifier = great_reformer
-        remove_country_modifier = gauche_buffoon
-        remove_country_modifier = administrative_genius
-        remove_country_modifier = visionary_thinker
-        remove_country_modifier = competent_placeholder
-        remove_country_modifier = imperious_autocrat
-        remove_country_modifier = prince_of_terror
-        remove_country_modifier = efficient_sociopath
-        remove_country_modifier = pig_headed_isolationist
-        remove_country_modifier = ambitious_union_boss
-        remove_country_modifier = dour_economist
-        add_country_modifier = {
-            name = power_vacuum
-            duration = 365
-        }
-    }
+	option = {
+		name = "He will be sorely missed."
+		random_owned = {
+			limit = {
+				OR = {
+					is_core = THIS
+					is_capital = yes
+				}
+			}
+			any_pop = { militancy = 2 }
+		}
+		remove_country_modifier = expert_diplomat
+		remove_country_modifier = successful_industrialist
+		remove_country_modifier = ivory_tower_intellectual
+		remove_country_modifier = man_of_the_people
+		remove_country_modifier = landed_gentleman
+		remove_country_modifier = military_man
+		remove_country_modifier = lord_admiral
+		remove_country_modifier = raving_loon
+		remove_country_modifier = luddite
+		remove_country_modifier = great_statesman
+		remove_country_modifier = backroom_boy
+		remove_country_modifier = great_reformer
+		remove_country_modifier = gauche_buffoon
+		remove_country_modifier = administrative_genius
+		remove_country_modifier = visionary_thinker
+		remove_country_modifier = competent_placeholder
+		remove_country_modifier = imperious_autocrat
+		remove_country_modifier = prince_of_terror
+		remove_country_modifier = efficient_sociopath
+		remove_country_modifier = pig_headed_isolationist
+		remove_country_modifier = ambitious_union_boss
+		remove_country_modifier = dour_economist
+		add_country_modifier = {
+			name = power_vacuum
+			duration = 365
+		}
+	}
 }


### PR DESCRIPTION
- Update political leaders so an ambitious union boss doesnt appear when UNIONS ARE BANNED
- Nor an industrialist when it's an unciv
- Also added a bit of flavour to a leader dying in a chattel (decide between +2 mil or +2 con basically)
- Also reduced code redundancy but now using the hide tooltip trick