### PR TITLE
Fix crimea war giving TCA some bs and serbian revolt not being sent to serbia/bosnia

### DIFF
--- a/GFM/decisions/Crimean War.txt
+++ b/GFM/decisions/Crimean War.txt
@@ -487,7 +487,6 @@ political_decisions = {
                     }
                 }
                 country_event = 97512
-                RUS = { treasury = 250000 }
             }
             diplomatic_influence = { who = TUR value = 50 }
             random_country = {

--- a/GFM/decisions/Crimean War.txt
+++ b/GFM/decisions/Crimean War.txt
@@ -483,9 +483,7 @@ political_decisions = {
                     tag = TUR
                     OR = {
                         THIS = { has_country_flag = crimean_surrender }
-                        TUR = {
-                            is_disarmed = yes
-                        }
+                        is_disarmed = yes
                     }
                 }
                 country_event = 97512

--- a/GFM/events/CrimeanWar.txt
+++ b/GFM/events/CrimeanWar.txt
@@ -478,6 +478,13 @@ country_event = {
 			end_war = THIS
 			annex_to = THIS
 		}
+		any_country = {
+            limit = {
+                tag = BUL
+                war_with = THIS
+            }
+            end_war = THIS
+        }
 
         any_owned = { #TCA exists
             limit = {
@@ -495,24 +502,14 @@ country_event = {
         }
 
         # Any Montenegran lands given to Montenegro, it is freed if vassaled
+        release = MON
+        release_vassal = MON
         any_owned = {
             limit = { is_core = MON }
             secede_province = MON
         }
-        random_country = {
-            limit = {
-                tag = MON
-                vassal_of = THIS
-            }
-            THIS = { release_vassal = MON }
-        }
 
         # Give Bulgaria, Eastern Rumelia and Silestre to Bulgaria, free it if vassaled
-
-		random_country = {
-            limit = { tag = BUL war_with = THIS }
-            end_war = THIS
-        }
         random_country = {
             limit = { tag = BUL vassal_of = THIS }
             THIS = { release_vassal = BUL }
@@ -565,61 +562,35 @@ country_event = {
         }
 
         # Thessalia, S. Macedonia returned to Greece
-        random_country = {
-            limit = {
-                tag = GRE
-                vassal_of = THIS
-            }
-            THIS = { release_vassal = GRE }
-        }
+        release = GRE
+        release_vassal = GRE
+        #Greece, with the above statment, will always exist
+        #And if turkey doesn't own 834 for some reason
+        #then the below statments will be false anyways
         random_owned = {
-            limit = {
-                province_id = 834 #Athens
-                NOT = { exists = GRE }
-            }
-            THIS = { release_vassal = GRE }
-        }
-
-        random_owned = {
-            limit = {
-                province_id = 834 #Athens
-				exists = GRE
-            }
-            state_scope = {
-                any_owned = {
-                    secede_province = GRE
+            limit = { province_id = 834 } #Athens
+            state_scope = { any_owned = { secede_province = GRE } }
+            THIS = { #Owner not safe, will be GRE after that secede
+                #Depends on owning athens!
+                random_owned = {
+                    limit = { province_id = 819 } #Florina
+                    state_scope = { any_owned = { secede_province = GRE } }
                 }
             }
         }
-        random_owned = {
+        any_owned = {
             limit = {
-                province_id = 819 #Florina
-                824 = { owned_by = GRE }
-            }
-            state_scope = {
-                any_owned = {
-                    secede_province = GRE
+                OR = {
+                    province_id = 832 #Volos
+                    province_id = 842 #Patras
                 }
             }
-        }
-        random_owned = {
-            limit = {
-                province_id = 832 #Volos
-            }
             state_scope = {
                 any_owned = {
-                    limit = { NOT = { province_id = 824 } } #Janina
-					limit = { NOT = { province_id = 3306 } } #Metsovo
-                    secede_province = GRE
-                }
-            }
-        }
-        random_owned = {
-            limit = {
-                province_id = 842 #Patras
-            }
-            state_scope = {
-                any_owned = {
+                    limit = {
+                        NOT = { province_id = 824 } #Janina
+					    NOT = { province_id = 3306 } #Metsovo
+                    }
                     secede_province = GRE
                 }
             }
@@ -633,89 +604,72 @@ country_event = {
             }
             owner = { release_vassal = SAM }
         }
-        random_country = {
+        any_country = {
             limit = {
                 OR = { #Only one, France or Borbon
                     tag = FRA
                     tag = BOR
+                    AND = {
+                        tag = ENG
+                        has_country_flag = england_protecting_interests
+                    }
                 }
                 exists = yes
             }
             prestige = -20
-            relation = { who = RUS value = -100 }
-            leave_alliance = RUS
+            relation = { who = FROM value = -100 }
+            leave_alliance = FROM
             casus_belli = {
-                target = RUS
+                target = FROM
                 type = take_from_sphere
                 months = 60
             }
             casus_belli = {
-                target = TUR
+                target = THIS
                 type = add_to_sphere
                 months = 60
             }
         }
-        random_country = {
-            limit = {
-                tag = ENG
-                has_country_flag = england_protecting_interests
-            }
-            prestige = -20
-            relation = { who = RUS value = -100 }
-            leave_alliance = RUS
-            casus_belli = {
-                target = RUS
-                type = take_from_sphere
-                months = 60
-            }
-            casus_belli = {
-                target = TUR
-                type = add_to_sphere
-                months = 60
-            }
-        }
-        RUS = {
-            military_access = TUR
-            diplomatic_influence = { who = TUR value = 100 }
-            relation = { who = TUR value = 200 }
-
-            relation = { who = SER value = 400 }
+        FROM = {
+            military_access = THIS
+            relation = { who = THIS value = 200 }
+            diplomatic_influence = { who = THIS value = 100 }
             diplomatic_influence = { who = SER value = 200 }
-            create_alliance = SER
-
-            relation = { who = BUL value = 400 }
             diplomatic_influence = { who = BUL value = 200 }
-            create_alliance = BUL
-
-            relation = { who = MON value = 400 }
             diplomatic_influence = { who = MON value = 200 }
-            create_alliance = MON
-
-            relation = { who = ROM value = 400 }
             diplomatic_influence = { who = ROM value = 200 }
-            create_alliance = ROM
         }
-        ROM = {
+        #Russia gains relations and influence with these countries
+        any_country = {
+            limit = {
+                OR = {
+                    tag = SER
+                    tag = MON
+                    tag = BUL
+                    tag = ROM
+                }
+            }
+            relation = { who = FROM value = 400 }
+            create_alliance = FROM
+        }
+        #And these specific countries get nationalistic agitations
+        any_country = {
+            limit = {
+                OR = {
+                    tag = BUL
+                    tag = GRE
+                    tag = ROM
+                }
+            }
             add_country_modifier = {
                 name = nationalist_balkans
                 duration = -1
             }
-            all_core = {
-                remove_core = WAL
-            }
         }
-        BUL = {
-            add_country_modifier = {
-                name = nationalist_balkans
-                duration = -1
-            }
-        }
-        GRE = {
-            add_country_modifier = {
-                name = nationalist_balkans
-                duration = -1
-            }
-        }
+        #No more Wallachia
+        WAL = { annex_to = ROM } #Failsafe if it somehow exists
+        ROM = { all_core = { remove_core = WAL } }
+        
 		release = BOS
 		release_vassal = BOS
         soldiers = {

--- a/GFM/events/CrimeanWar.txt
+++ b/GFM/events/CrimeanWar.txt
@@ -495,6 +495,8 @@ country_event = {
                 OR = { region = TUR_885 province_id = 1096 }
             }
             secede_province = TCA
+            add_core = TCA
+            add_core = FROM
         }
         any_owned = { #TCA doesn't exist
             limit = {
@@ -502,6 +504,8 @@ country_event = {
                 OR = { region = TUR_885 province_id = 1096 }
             }
             secede_province = FROM
+            add_core = TCA
+            add_core = FROM
         }
 
         # Any Montenegran lands given to Montenegro, it is freed if vassaled

--- a/GFM/events/CrimeanWar.txt
+++ b/GFM/events/CrimeanWar.txt
@@ -438,6 +438,7 @@ country_event = {
     }
 }
 
+#THIS is TUR, FROM is RUS
 country_event = {
     id = 97512
     title = "EVTNAME97510" #The Treaty of Paris (Russian Version)
@@ -465,18 +466,32 @@ country_event = {
             secede_province = ROM
         }
 		any_country = {
-			limit = { tag = BOS war_with = THIS }
+			limit = {
+                OR = {
+                    tag = BOS #Bosnia
+                    #Annexed so we give lands to bosnia/serbia
+                    tag = SRR #Serbian Revolt
+                    tag = ALB #Albania
+                }
+                war_with = THIS
+            }
 			end_war = THIS
 			annex_to = THIS
 		}
-		any_country = {
-			limit = { tag = ALB war_with = THIS }
-			end_war = THIS
-			annex_to = THIS
-		}
-        any_owned = {
-            limit = { OR = { region = TUR_885 province_id = 1096 } }
+
+        any_owned = { #TCA exists
+            limit = {
+                exists = TCA
+                OR = { region = TUR_885 province_id = 1096 }
+            }
             secede_province = TCA
+        }
+        any_owned = { #TCA doesn't exist
+            limit = {
+                NOT = { exists = TCA }
+                OR = { region = TUR_885 province_id = 1096 }
+            }
+            secede_province = FROM
         }
 
         # Any Montenegran lands given to Montenegro, it is freed if vassaled
@@ -487,155 +502,82 @@ country_event = {
         random_country = {
             limit = {
                 tag = MON
-                vassal_of = TUR
+                vassal_of = THIS
             }
-            TUR = { release_vassal = MON }
+            THIS = { release_vassal = MON }
         }
 
         # Give Bulgaria, Eastern Rumelia and Silestre to Bulgaria, free it if vassaled
 
 		random_country = {
-            limit = {
-                tag = BUL
-                war_with = TUR
-            }
-            end_war = TUR
+            limit = { tag = BUL war_with = THIS }
+            end_war = THIS
         }
         random_country = {
-            limit = {
-                tag = BUL
-                vassal_of = TUR
-            }
-            TUR = { release_vassal = BUL }
+            limit = { tag = BUL vassal_of = THIS }
+            THIS = { release_vassal = BUL }
         }
         random_owned = {
             limit = {
-                province_id = 817 #Burgas
-                owned_by = TUR
-            }
-            state_scope = {
-                any_owned = {
-                    secede_province = BUL
+                OR = {
+                    province_id = 817 #Burgas
+                    province_id = 812 #Pleven
                 }
             }
+            state_scope = { any_owned = { secede_province = BUL } }
         }
         random_owned = {
             limit = {
-                province_id = 812 #Pleven
-                owned_by = TUR
-            }
-            state_scope = {
-                any_owned = {
-                    secede_province = BUL
+                OR = {
+                    province_id = 818 #Silistre
+                    province_id = 3371 #Mangalia
                 }
-            }
-        }
-        random_owned = {
-            limit = {
-                province_id = 818 #Silistre
-                owned_by = TUR
-            }
-            secede_province = BUL
-        }
-        random_owned = {
-            limit = {
-                province_id = 3371 #Mangalia
-                owned_by = TUR
             }
             secede_province = BUL
         }
 
         # Free Serbia if it is owned, return Nis, Leskovac
         random_owned = {
+            limit = { province_id = 794 } #Belgrade
+            state_scope = { any_owned = { secede_province = SER } }
+        }
+        random_owned = {
             limit = {
-                province_id = 794 #Belgrade
-                owned_by = TUR
-            }
-            state_scope = {
-                any_owned = {
-                    secede_province = SER
+                OR = {
+                    province_id = 798 #Nis
+                    province_id = 799 #Leskovac
+                    province_id = 3347 #Nis
+                    province_id = 795 #Leskovac
+                    province_id = 3933 #Leskovac
+                    province_id = 3934 #Leskovac
+                    province_id = 3346 #Krusevay
+                    province_id = 804 #Krusevay
                 }
-            }
-        }
-        random_owned = {
-            limit = {
-                province_id = 798 #Nis
-                owned_by = TUR
-            }
-            secede_province = SER
-        }
-        random_owned = {
-            limit = {
-                province_id = 799 #Leskovac
-                owned_by = TUR
-            }
-            secede_province = SER
-        }
-        random_owned = {
-            limit = {
-                province_id = 3347 #Nis
-                owned_by = TUR
-            }
-            secede_province = SER
-        }
-        random_owned = {
-            limit = {
-                province_id = 795 #Leskovac
-                owned_by = TUR
-            }
-            secede_province = SER
-        }
-        random_owned = {
-            limit = {
-                province_id = 3933 #Leskovac
-                owned_by = TUR
-            }
-            secede_province = SER
-        }
-        random_owned = {
-            limit = {
-                province_id = 3934 #Leskovac
-                owned_by = TUR
-            }
-            secede_province = SER
-        }
-        random_owned = {
-            limit = {
-                province_id = 3346 #Krusevay
-                owned_by = TUR
-            }
-            secede_province = SER
-        }
-        random_owned = {
-            limit = {
-                province_id = 804 #Krusevay
-                owned_by = TUR
             }
             secede_province = SER
         }
         random_country = {
             limit = {
                 tag = SER
-                vassal_of = TUR
+                vassal_of = THIS
             }
-            TUR = { release_vassal = SER }
+            THIS = { release_vassal = SER }
         }
 
         # Thessalia, S. Macedonia returned to Greece
         random_country = {
             limit = {
                 tag = GRE
-                vassal_of = TUR
+                vassal_of = THIS
             }
-            TUR = { release_vassal = GRE }
+            THIS = { release_vassal = GRE }
         }
         random_owned = {
             limit = {
                 province_id = 834 #Athens
-                owned_by = TUR
                 NOT = { exists = GRE }
             }
-            owner = { release_vassal = GRE }
+            THIS = { release_vassal = GRE }
         }
 
         random_owned = {

--- a/GFM/events/CrimeanWar.txt
+++ b/GFM/events/CrimeanWar.txt
@@ -517,7 +517,7 @@ country_event = {
             limit = { tag = BUL vassal_of = THIS }
             THIS = { release_vassal = BUL }
         }
-        random_owned = {
+        any_owned = {
             limit = {
                 OR = {
                     province_id = 817 #Burgas
@@ -526,7 +526,7 @@ country_event = {
             }
             state_scope = { any_owned = { secede_province = BUL } }
         }
-        random_owned = {
+        any_owned = {
             limit = {
                 OR = {
                     province_id = 818 #Silistre
@@ -537,11 +537,11 @@ country_event = {
         }
 
         # Free Serbia if it is owned, return Nis, Leskovac
-        random_owned = {
+        any_owned = {
             limit = { province_id = 794 } #Belgrade
             state_scope = { any_owned = { secede_province = SER } }
         }
-        random_owned = {
+        any_owned = {
             limit = {
                 OR = {
                     province_id = 798 #Nis
@@ -583,7 +583,6 @@ country_event = {
         random_owned = {
             limit = {
                 province_id = 834 #Athens
-                owned_by = TUR
 				exists = GRE
             }
             state_scope = {
@@ -595,7 +594,6 @@ country_event = {
         random_owned = {
             limit = {
                 province_id = 819 #Florina
-                owned_by = TUR
                 824 = { owned_by = GRE }
             }
             state_scope = {
@@ -607,7 +605,6 @@ country_event = {
         random_owned = {
             limit = {
                 province_id = 832 #Volos
-                owned_by = TUR
             }
             state_scope = {
                 any_owned = {
@@ -620,7 +617,6 @@ country_event = {
         random_owned = {
             limit = {
                 province_id = 842 #Patras
-                owned_by = TUR
             }
             state_scope = {
                 any_owned = {
@@ -633,48 +629,32 @@ country_event = {
         random_owned = {
             limit = {
                 province_id = 843 #Chios & Samos
-                owned_by = TUR
                 NOT = { exists = SAM }
             }
             owner = { release_vassal = SAM }
         }
-        random_owned = {
-            limit = { exists = FRA }
-            FRA = {
-                prestige = -20
-                relation = { who = RUS value = -100 }
-                leave_alliance = RUS
-                casus_belli = {
-                    target = RUS
-                    type = take_from_sphere
-                    months = 60
+        random_country = {
+            limit = {
+                OR = { #Only one, France or Borbon
+                    tag = FRA
+                    tag = BOR
                 }
-                casus_belli = {
-                    target = TUR
-                    type = add_to_sphere
-                    months = 60
-                }
+                exists = yes
+            }
+            prestige = -20
+            relation = { who = RUS value = -100 }
+            leave_alliance = RUS
+            casus_belli = {
+                target = RUS
+                type = take_from_sphere
+                months = 60
+            }
+            casus_belli = {
+                target = TUR
+                type = add_to_sphere
+                months = 60
             }
         }
-        random_owned = {
-            limit = { exists = BOR }
-            BOR = {
-                prestige = -20
-                relation = { who = RUS value = -100 }
-                leave_alliance = RUS
-                casus_belli = {
-                    target = RUS
-                    type = take_from_sphere
-                    months = 60
-                }
-                casus_belli = {
-                    target = TUR
-                    type = add_to_sphere
-                    months = 60
-                }
-            }
-        }
-
         random_country = {
             limit = {
                 tag = ENG

--- a/GFM/events/CrimeanWar.txt
+++ b/GFM/events/CrimeanWar.txt
@@ -668,8 +668,8 @@ country_event = {
                 duration = -1
             }
         }
-        #No more Wallachia
-        WAL = { annex_to = ROM } #Failsafe if it somehow exists
+        #No more Wallachia - Failsafe if it somehow exists
+        WAL = { change_tag = ROM }
         ROM = { all_core = { remove_core = WAL } }
         
 		release = BOS

--- a/GFM/events/CrimeanWar.txt
+++ b/GFM/events/CrimeanWar.txt
@@ -534,8 +534,17 @@ country_event = {
         }
 
         # Free Serbia if it is owned, return Nis, Leskovac
+        random_country = {
+            limit = { tag = SER vassal_of = THIS }
+            THIS = { release_vassal = SER }
+        }
         any_owned = {
-            limit = { province_id = 794 } #Belgrade
+            limit = {
+                OR = {
+                    province_id = 794 #Belgrade
+                    province_id = 802
+                    province_id = 806
+                }
             state_scope = { any_owned = { secede_province = SER } }
         }
         any_owned = {
@@ -552,13 +561,6 @@ country_event = {
                 }
             }
             secede_province = SER
-        }
-        random_country = {
-            limit = {
-                tag = SER
-                vassal_of = THIS
-            }
-            THIS = { release_vassal = SER }
         }
 
         # Thessalia, S. Macedonia returned to Greece

--- a/GFM/events/CrimeanWar.txt
+++ b/GFM/events/CrimeanWar.txt
@@ -504,7 +504,6 @@ country_event = {
                 OR = { region = TUR_885 province_id = 1096 }
             }
             secede_province = FROM
-            add_core = TCA
             add_core = FROM
         }
 

--- a/GFM/events/CrimeanWar.txt
+++ b/GFM/events/CrimeanWar.txt
@@ -454,7 +454,10 @@ country_event = {
     option = {
         name = "EVT97512OPTA"
         prestige = -20
-        treasury = -250000
+        
+        THIS = { treasury = -250000 } #Take
+        FROM = { treasury = 250000 } #Pay
+
         any_owned = {
             limit = {
                 OR = {
@@ -539,12 +542,7 @@ country_event = {
             THIS = { release_vassal = SER }
         }
         any_owned = {
-            limit = {
-                OR = {
-                    province_id = 794 #Belgrade
-                    province_id = 802
-                    province_id = 806
-                }
+            limit = { province_id = 794 } #Belgrade
             state_scope = { any_owned = { secede_province = SER } }
         }
         any_owned = {
@@ -564,8 +562,10 @@ country_event = {
         }
 
         # Thessalia, S. Macedonia returned to Greece
-        release = GRE
-        release_vassal = GRE
+        random_owned = {
+            limit = { exists = GRE vassal_of = THIS }
+            THIS = { release_vassal = GRE }
+        }
         #Greece, with the above statment, will always exist
         #And if turkey doesn't own 834 for some reason
         #then the below statments will be false anyways


### PR DESCRIPTION
- TCA no longer gets free shit if russia annexxed them
- ok lemme explain:
```
                    tag = TUR
                    OR = {
                        THIS = { has_country_flag = crimean_surrender }
                        TUR = {
                            is_disarmed = yes
                        }
                        is_disarmed = yes
                    }
```
this trigger, is already scoping `TUR`, so like, `TUR = { is_disarmed = yes }` is totally redundant
- Serbian Revolt now properly annexed to turkey TO LATER give them bosnain and serbian lands properly
