### PR TITLE
Removes RPL Core from Yakutat

### DIFF
--- a/GFM/history/provinces/usa/2 - Yakutat.txt
+++ b/GFM/history/provinces/usa/2 - Yakutat.txt
@@ -1,7 +1,6 @@
 owner = RUS
 controller = RUS
 add_core = LSK
-add_core = RPL
 trade_goods = fish
 life_rating = 20
 colonial = 2


### PR DESCRIPTION
Removes the core that Hudson Bay Company/Ruperts Land gets on Alaska's capital, removing a free beli Canada gets on the USA, and removes it as a requirement for Quebec to form French Canada when they inherit the land. 

Works in-game
![image](https://github.com/user-attachments/assets/1f6b8eb2-8c06-470f-b244-46cdb1ce1e16)
