### PR TITLE
SPAFlavor.txt

### DIFF
--- a/GFM/events/SPAFlavor.txt
+++ b/GFM/events/SPAFlavor.txt
@@ -2538,7 +2538,7 @@ country_event = {
     is_triggered_only = yes
 
     option = {
-        name = "Cuba is and will forever be American. §RGain 3 infamy.§W"
+        name = "Cuba is and will forever be American. Â§RGain 3 infamy.Â§W"
         prestige = 40
         money = -500000
 		inherit = CUB
@@ -2577,7 +2577,7 @@ country_event = {
 		ai_chance = { factor = 1 }
     }
     option = {
-        name = "We recognize Cuba as an independent state. §GLose 1 infamy§W"
+        name = "We recognize Cuba as an independent state. Â§GLose 1 infamyÂ§W"
 		badboy = -1
         relation = {
             who = FROM
@@ -3088,7 +3088,7 @@ country_event = {
 country_event = {
     id = 112333
     title = "The Chincha Islands War"
-    desc = "Spain has occupied the valuable guano-rich Chincha Islands along our coast to pressure us into paying indemnities for the Talambó Incident."
+    desc = "Spain has occupied the valuable guano-rich Chincha Islands along our coast to pressure us into paying indemnities for the TalambÃ³ Incident."
     picture = "numancia"
 	
     is_triggered_only = yes
@@ -3132,7 +3132,7 @@ country_event = {
 country_event = {
     id = 112334
     title = "The Chincha Islands War"
-    desc = "Spain has occupied the valuable guano-rich Chincha Islands in $FROMCOUNTRY$ to pressure them into paying indemnties for the Talambó Incident. Shall we support them?"
+    desc = "Spain has occupied the valuable guano-rich Chincha Islands in $FROMCOUNTRY$ to pressure them into paying indemnties for the TalambÃ³ Incident. Shall we support them?"
     picture = "numancia"
 	
     is_triggered_only = yes
@@ -3857,6 +3857,7 @@ country_event = {
         OR = {
             tag = SPA
             tag = SPC
+            tag = IBR
         }
         OR = {
             has_global_flag = spain_glorious_revolution


### PR DESCRIPTION
Fixing a permanent debuff if you form Iberia. If you form Iberia, before 1880 with Spain, you don't get the event cleaning the province modifier of the carlists/christinos sympathies in the End of the carlists/christinos event 