### PR TITLE
fix SAFFlavor.txt

### DIFF
--- a/GFM/events/SAFFlavor.txt
+++ b/GFM/events/SAFFlavor.txt
@@ -495,7 +495,7 @@ country_event = {
         owns = 2095
         owns = 2101
         owns = 2106
-        THIS = { capital_scope = { continent = africa } }
+        THIS = { capital_scope = { continent = south_africa } }
         NOT = { has_country_flag = mineral_revolution }
     }
 
@@ -810,7 +810,7 @@ country_event = {
         remove_country_modifier = native_reintegration
         any_owned = {
             limit = {
-                continent = africa
+                continent = south_africa
                 any_pop = { is_culture_group = southern_african }
             }
             add_province_modifier = {
@@ -871,7 +871,7 @@ country_event = {
         remove_country_modifier = native_reintegration
         any_owned = {
             limit = {
-                continent = africa
+                continent = south_africa
                 any_pop = { is_culture_group = southern_african }
             }
             add_province_modifier = {
@@ -1155,7 +1155,7 @@ country_event = {
         ai_chance = { factor = 1 }
     }
     option = {
-        name = "For Zoutpansberg! §BPlay as Zoutpansberg§W"
+        name = "For Zoutpansberg! Â§BPlay as ZoutpansbergÂ§W"
 		3969 = {
             any_pop = {
                 limit = {
@@ -1187,7 +1187,7 @@ country_event = {
         ai_chance = { factor = 0 }
     }
     option = {
-        name = "We can't let this happen in our heartland. §RDeclare war on Zoutpansberg§W"
+        name = "We can't let this happen in our heartland. Â§RDeclare war on ZoutpansbergÂ§W"
 		3969 = {
             any_pop = {
                 limit = {
@@ -1254,7 +1254,7 @@ country_event = {
         ai_chance = { factor = 1 }
     }
     option = {
-        name = "For Zoutpansberg! §BPlay as Zoutpansberg§W"
+        name = "For Zoutpansberg! Â§BPlay as ZoutpansbergÂ§W"
 		any_pop = { consciousness = 1 }
 		prestige = 1
 		change_tag_no_core_switch = NRB
@@ -2185,7 +2185,7 @@ country_event = {
     }
 
     option = {
-        name = "Let the negotiations begin. §RGain 4 infamy§W"
+        name = "Let the negotiations begin. Â§RGain 4 infamyÂ§W"
         badboy = 4
         set_country_flag = annexed_puppet_SAF
         THIS = { inherit = TSW }


### PR DESCRIPTION
African continent name split out in map/continent.txt breaks these two events and probably other african countries who's events conditions are based on "africa" and not "[area]_africa".

Ignore/remove the stupid encoding changes that happened from editing in git